### PR TITLE
Added routes for pets, owners and appointments

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from app.routes import pets, owners, appointments 
 from app.db.database import engine, Base
 import app.models
 from sqlalchemy import inspect
@@ -17,3 +18,7 @@ def read_main() -> Dict[str, str]:
 def list_tables():
     inspector = inspect(engine)
     return {"tables": inspector.get_table_names()}
+
+app.include_router(pets.router, prefix="/pets", tags=["Pets"])
+app.include_router(owners.router, prefix="/owners", tags=["Owners"])
+app.include_router(appointments.router, prefix="/appointments", tags=["Appointments"])

--- a/app/routes/appointments.py
+++ b/app/routes/appointments.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.db.database import get_db
+from app import models, schemas
+
+router = APIRouter()
+
+@router.post("/", response_model=schemas.Appointment)
+def create_appointment(appointment: schemas.AppointmentCreate, db: Session = Depends(get_db)):
+    db_appointment = models.Appointment(**appointment.model_dump())
+    db.add(db_appointment)
+    db.commit()
+    db.refresh(db_appointment)
+    return db_appointment
+
+@router.get("/{appointment_id}", response_model=schemas.Appointment)
+def read_appointment(appointment_id: int, db: Session = Depends(get_db)):
+    db_appointment = db.query(models.Appointment).filter(models.Appointment.id == appointment_id).first()
+    if db_appointment is None:
+        raise HTTPException(status_code=404, detail="Appointment not found")
+    return db_appointment
+
+@router.get("/", response_model=List[schemas.Appointment])
+def read_appointments(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    appointments = db.query(models.Appointment).offset(skip).limit(limit).all()
+    return appointments

--- a/app/routes/owners.py
+++ b/app/routes/owners.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.db.database import get_db
+from app import models, schemas
+
+router = APIRouter()
+
+@router.post("/", response_model=schemas.Owner)
+def create_owner(owner: schemas.OwnerCreate, db: Session = Depends(get_db)):
+    db_owner = models.Owner(**owner.model_dump())
+    db.add(db_owner)
+    db.commit()
+    db.refresh(db_owner)
+    return db_owner
+
+@router.get("/{owner_id}", response_model=schemas.Owner)
+def read_owner(owner_id: int, db: Session = Depends(get_db)):
+    db_owner = db.query(models.Owner).filter(models.Owner.id == owner_id).first()
+    if db_owner is None:
+        raise HTTPException(status_code=404, detail="Owner not found")
+    return db_owner
+
+@router.get("/", response_model=List[schemas.Owner])
+def read_owners(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    owners = db.query(models.Owner).offset(skip).limit(limit).all()
+    return owners

--- a/app/routes/pets.py
+++ b/app/routes/pets.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.db.database import get_db
+from app import models, schemas
+
+router = APIRouter()
+
+@router.post("/", response_model=schemas.Pet)
+def create_pet(pet: schemas.PetCreate, db: Session = Depends(get_db)):
+    db_pet = models.Pet(**pet.model_dump())
+    db.add(db_pet)
+    db.commit()
+    db.refresh(db_pet)
+    return db_pet
+
+@router.get("/{pet_id}", response_model=schemas.Pet)
+def read_pet(pet_id: int, db: Session = Depends(get_db)):
+    db_pet = db.query(models.Pet).filter(models.Pet.id == pet_id).first()
+    if db_pet is None:
+        raise HTTPException(status_code=404, detail="Pet not found")
+    return db_pet
+
+@router.get("/", response_model=List[schemas.Pet])
+def read_pets(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    pets = db.query(models.Pet).offset(skip).limit(limit).all()
+    return pets

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,3 @@
+from .pet import Pet, PetCreate, PetBase
+from .owner import Owner, OwnerCreate, OwnerBase
+from .appointment import Appointment, AppointmentCreate, AppointmentBase

--- a/app/schemas/appointment.py
+++ b/app/schemas/appointment.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+from typing import Optional
+from datetime import datetime
+
+class AppointmentBase(BaseModel):
+    pet_id: int
+    appointment_date: datetime
+    reason: Optional[str] = None
+
+class AppointmentCreate(AppointmentBase):
+    pass
+
+class Appointment(AppointmentBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/owner.py
+++ b/app/schemas/owner.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from typing import Optional, List
+from .pet import Pet
+
+class OwnerBase(BaseModel):
+    full_name: str
+    email: str
+    phone_number: Optional[str] = None
+
+class OwnerCreate(OwnerBase):
+    pass
+
+class Owner(OwnerBase):
+    id: int
+    pets: List[Pet] = []
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/pet.py
+++ b/app/schemas/pet.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class PetBase(BaseModel):
+    name: str
+    species: str
+    breed: Optional[str] = None
+    age: Optional[int] = None
+    owner_id: Optional[int] = None
+
+class PetCreate(PetBase):
+    pass
+
+class Pet(PetBase):
+    id: int
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
This pull request introduces new API routes for managing pets, owners, and appointments in a FastAPI application. It also adds corresponding Pydantic schemas for data validation and serialization. The changes enhance the application's functionality by providing CRUD operations for these entities.

### API Routes Implementation:

* Added new routes in `app/routes/appointments.py` for creating, retrieving, and listing appointments. These routes handle interactions with the `Appointment` model.
* Added new routes in `app/routes/owners.py` for creating, retrieving, and listing owners, interacting with the `Owner` model.
* Added new routes in `app/routes/pets.py` for creating, retrieving, and listing pets, interacting with the `Pet` model.

### Pydantic Schemas:

* Introduced `AppointmentBase`, `AppointmentCreate`, and `Appointment` schemas in `app/schemas/appointment.py` for validating and serializing appointment data.
* Introduced `OwnerBase`, `OwnerCreate`, and `Owner` schemas in `app/schemas/owner.py` for validating and serializing owner data.
* Introduced `PetBase`, `PetCreate`, and `Pet` schemas in `app/schemas/pet.py` for validating and serializing pet data.

### Application Integration:

* Updated `app/main.py` to include routers for pets, owners, and appointments, with appropriate prefixes and tags for API documentation. [[1]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR2) [[2]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR21-R24)
* Updated `app/schemas/__init__.py` to import all newly created schemas for easier access across the application.