### PR TITLE
Added API tests for pets, owners and appointments

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -1,6 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, declarative_base
 
 DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/veterinary_db"
 

--- a/app/schemas/appointment.py
+++ b/app/schemas/appointment.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import Optional
 from datetime import datetime
 
@@ -11,7 +11,5 @@ class AppointmentCreate(AppointmentBase):
     pass
 
 class Appointment(AppointmentBase):
+    model_config = ConfigDict(from_attributes=True)
     id: int
-
-    class Config:
-        orm_mode = True

--- a/app/schemas/owner.py
+++ b/app/schemas/owner.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import Optional, List
 from .pet import Pet
 
@@ -11,8 +11,6 @@ class OwnerCreate(OwnerBase):
     pass
 
 class Owner(OwnerBase):
+    model_config = ConfigDict(from_attributes=True)
     id: int
     pets: List[Pet] = []
-
-    class Config:
-        orm_mode = True

--- a/app/schemas/pet.py
+++ b/app/schemas/pet.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import Optional
 
 class PetBase(BaseModel):
@@ -12,7 +12,5 @@ class PetCreate(PetBase):
     pass
 
 class Pet(PetBase):
+    model_config = ConfigDict(from_attributes=True)
     id: int
-
-    class Config:
-        orm_mode = True

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,121 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from datetime import datetime, timezone # Added timezone for robust datetime handling
+
+from app.main import app
+from app.db.database import Base, get_db
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+def override_get_db():
+    try:
+        db = TestingSessionLocal()
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_test_database():
+    Base.metadata.create_all(bind=engine)
+    yield
+
+@pytest.fixture(scope="function")
+def db_session():
+    connection = engine.connect()
+    transaction = connection.begin()
+
+    session = TestingSessionLocal(bind=connection)
+    
+    yield session
+    
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+@pytest.fixture(scope="function")
+def client(db_session):
+
+    original_override = app.dependency_overrides.get(get_db)
+
+
+    def _override_get_db_for_client():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db_for_client
+    
+    with TestClient(app) as c:
+        yield c
+    
+    if original_override:
+        app.dependency_overrides[get_db] = original_override
+    else:
+        app.dependency_overrides[get_db] = override_get_db
+
+
+
+@pytest.fixture(scope="function")
+def test_owner_data_factory():
+    def _factory(email_suffix=""):
+        return {
+            "full_name": "Test Owner",
+            "email": f"test.owner{email_suffix}@example.com",
+            "phone_number": "1234567890"
+        }
+    return _factory
+
+@pytest.fixture(scope="function")
+def created_test_owner(client, test_owner_data_factory):
+    owner_data = test_owner_data_factory()
+    response = client.post("/owners/", json=owner_data)
+    assert response.status_code == 200
+    return response.json()
+
+@pytest.fixture(scope="function")
+def test_pet_data_factory(created_test_owner):
+    def _factory(owner_id=None):
+        return {
+            "name": "Test Pet",
+            "species": "Dog",
+            "breed": "Labrador",
+            "age": 3,
+            "owner_id": owner_id or created_test_owner["id"]
+        }
+    return _factory
+
+@pytest.fixture(scope="function")
+def created_test_pet(client, test_pet_data_factory):
+    pet_data = test_pet_data_factory()
+    response = client.post("/pets/", json=pet_data)
+    assert response.status_code == 200
+    return response.json()
+
+@pytest.fixture(scope="function")
+def test_appointment_data_factory(created_test_pet):
+    def _factory(pet_id=None, appointment_time=None):
+        appointment_dt = appointment_time or datetime.now(timezone.utc)
+        return {
+            "pet_id": pet_id or created_test_pet["id"],
+            "appointment_date": appointment_dt.isoformat(),
+            "reason": "Regular checkup"
+        }
+    return _factory
+
+@pytest.fixture(scope="function")
+def created_test_appointment(client, test_appointment_data_factory):
+    appointment_data = test_appointment_data_factory()
+    response = client.post("/appointments/", json=appointment_data)
+    assert response.status_code == 200
+    return response.json()

--- a/app/tests/test_appointments.py
+++ b/app/tests/test_appointments.py
@@ -1,0 +1,81 @@
+from fastapi.testclient import TestClient
+from datetime import datetime, timedelta, timezone
+
+def test_create_appointment(client: TestClient, created_test_pet, test_appointment_data_factory):
+    appointment_dt = datetime.now(timezone.utc) + timedelta(days=5)
+    appointment_data = test_appointment_data_factory(
+        pet_id=created_test_pet["id"],
+        appointment_time=appointment_dt
+    )
+    appointment_data["reason"] = "Follow-up"
+
+    response = client.post("/appointments/", json=appointment_data)
+    assert response.status_code == 200
+    created_appointment = response.json()
+    assert created_appointment["reason"] == appointment_data["reason"]
+    assert created_appointment["pet_id"] == created_test_pet["id"]
+    assert "id" in created_appointment
+
+    assert created_appointment["appointment_date"] == appointment_dt.replace(tzinfo=None).isoformat()
+
+def test_read_appointment(client: TestClient, created_test_appointment):
+    appointment_id = created_test_appointment["id"]
+    response = client.get(f"/appointments/{appointment_id}")
+    assert response.status_code == 200
+    appointment = response.json()
+    assert appointment["id"] == appointment_id
+    assert appointment["reason"] == created_test_appointment["reason"]
+
+def test_read_appointment_not_found(client: TestClient):
+    response = client.get("/appointments/99999")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Appointment not found"}
+
+def test_read_appointments_empty(client: TestClient):
+    response = client.get("/appointments/")
+    assert response.status_code == 200
+    assert response.json() == []
+
+def test_read_appointments_with_data(client: TestClient, created_test_appointment, test_appointment_data_factory, created_test_pet):
+    appointment_data_2 = test_appointment_data_factory(
+        pet_id=created_test_pet["id"],
+        appointment_time=datetime.now(timezone.utc) + timedelta(days=10)
+    )
+    appointment_data_2["reason"] = "Vaccination"
+    client.post("/appointments/", json=appointment_data_2)
+
+    response = client.get("/appointments/")
+    assert response.status_code == 200
+    appointments = response.json()
+    assert len(appointments) >= 2
+    assert any(a["reason"] == created_test_appointment["reason"] for a in appointments)
+    assert any(a["reason"] == appointment_data_2["reason"] for a in appointments)
+
+def test_read_appointments_pagination(client: TestClient, test_appointment_data_factory, created_test_pet):
+    for i in range(5):
+        appt_data = test_appointment_data_factory(
+            pet_id=created_test_pet["id"],
+            appointment_time=datetime.now(timezone.utc) + timedelta(days=i+1)
+        )
+        appt_data["reason"] = f"Paginated Appt {i}"
+        client.post("/appointments/", json=appt_data)
+
+    response_limit_2 = client.get("/appointments/?skip=0&limit=2")
+    assert response_limit_2.status_code == 200
+    data_limit_2 = response_limit_2.json()
+    assert len(data_limit_2) == 2
+
+    response_skip_2_limit_2 = client.get("/appointments/?skip=2&limit=2")
+    assert response_skip_2_limit_2.status_code == 200
+    data_skip_2_limit_2 = response_skip_2_limit_2.json()
+    assert len(data_skip_2_limit_2) == 2
+    assert data_limit_2[0]["id"] != data_skip_2_limit_2[0]["id"]
+
+def test_create_appointment_invalid_date_format(client: TestClient, created_test_pet):
+    appointment_data = {
+        "pet_id": created_test_pet["id"],
+        "appointment_date": "not-a-valid-date",
+        "reason": "Checkup with invalid date"
+    }
+    response = client.post("/appointments/", json=appointment_data)
+    assert response.status_code == 422

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+
+def test_read_main(client: TestClient):
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"msg": "app is running"}
+
+def test_list_tables(client: TestClient):
+    response = client.get("/tables")
+    assert response.status_code == 200
+    
+    data = response.json()
+
+    assert "tables" in data
+
+    assert "owner" in data["tables"]
+    assert "pet" in data["tables"]
+    assert "appointment" in data["tables"]

--- a/app/tests/test_owners.py
+++ b/app/tests/test_owners.py
@@ -1,0 +1,56 @@
+from fastapi.testclient import TestClient
+
+def test_create_owner(client: TestClient, test_owner_data_factory):
+    owner_data = test_owner_data_factory(email_suffix="_create_owner")
+    response = client.post("/owners/", json=owner_data)
+    assert response.status_code == 200
+    created_owner = response.json()
+    assert created_owner["email"] == owner_data["email"]
+    assert "id" in created_owner
+    assert created_owner["full_name"] == owner_data["full_name"]
+    assert created_owner["pets"] == []
+
+def test_read_owner(client: TestClient, created_test_owner):
+    owner_id = created_test_owner["id"]
+    response = client.get(f"/owners/{owner_id}")
+    assert response.status_code == 200
+    owner = response.json()
+    assert owner["id"] == owner_id
+    assert owner["email"] == created_test_owner["email"]
+
+def test_read_owner_not_found(client: TestClient):
+    response = client.get("/owners/99999")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Owner not found"}
+
+def test_read_owners_empty(client: TestClient):
+    response = client.get("/owners/")
+    assert response.status_code == 200
+    assert response.json() == []
+
+def test_read_owners_with_data(client: TestClient, created_test_owner, test_owner_data_factory):
+    owner_data_2 = test_owner_data_factory(email_suffix="_owner2")
+    client.post("/owners/", json=owner_data_2)
+
+    response = client.get("/owners/")
+    assert response.status_code == 200
+    owners = response.json()
+    assert len(owners) >= 2
+    assert any(o["email"] == created_test_owner["email"] for o in owners)
+    assert any(o["email"] == owner_data_2["email"] for o in owners)
+
+def test_read_owners_pagination(client: TestClient, test_owner_data_factory):
+    for i in range(5):
+        client.post("/owners/", json=test_owner_data_factory(email_suffix=f"_page_owner{i}"))
+
+    response_limit_2 = client.get("/owners/?skip=0&limit=2")
+    assert response_limit_2.status_code == 200
+    data_limit_2 = response_limit_2.json()
+    assert len(data_limit_2) == 2
+
+    response_skip_2_limit_2 = client.get("/owners/?skip=2&limit=2")
+    assert response_skip_2_limit_2.status_code == 200
+    data_skip_2_limit_2 = response_skip_2_limit_2.json()
+    assert len(data_skip_2_limit_2) == 2
+    
+    assert data_limit_2[0]["id"] != data_skip_2_limit_2[0]["id"]

--- a/app/tests/test_pets.py
+++ b/app/tests/test_pets.py
@@ -1,0 +1,64 @@
+from fastapi.testclient import TestClient
+
+def test_create_pet(client: TestClient, created_test_owner, test_pet_data_factory):
+    pet_data = test_pet_data_factory(owner_id=created_test_owner["id"])
+    pet_data["name"] = "New Buddy"
+    
+    response = client.post("/pets/", json=pet_data)
+    assert response.status_code == 200
+    created_pet = response.json()
+    assert created_pet["name"] == pet_data["name"]
+    assert created_pet["owner_id"] == created_test_owner["id"]
+    assert "id" in created_pet
+
+    owner_response = client.get(f"/owners/{created_test_owner['id']}")
+    owner_data = owner_response.json()
+    assert any(p["id"] == created_pet["id"] for p in owner_data["pets"])
+
+
+def test_read_pet(client: TestClient, created_test_pet):
+    pet_id = created_test_pet["id"]
+    response = client.get(f"/pets/{pet_id}")
+    assert response.status_code == 200
+    pet = response.json()
+    assert pet["id"] == pet_id
+    assert pet["name"] == created_test_pet["name"]
+
+def test_read_pet_not_found(client: TestClient):
+    response = client.get("/pets/99999")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Pet not found"}
+
+def test_read_pets_empty(client: TestClient):
+    response = client.get("/pets/")
+    assert response.status_code == 200
+    assert response.json() == []
+
+def test_read_pets_with_data(client: TestClient, created_test_pet, test_pet_data_factory, created_test_owner):
+    pet_data_2 = test_pet_data_factory(owner_id=created_test_owner["id"])
+    pet_data_2["name"] = "Second Pet"
+    client.post("/pets/", json=pet_data_2)
+
+    response = client.get("/pets/")
+    assert response.status_code == 200
+    pets = response.json()
+    assert len(pets) >= 2
+    assert any(p["name"] == created_test_pet["name"] for p in pets)
+    assert any(p["name"] == pet_data_2["name"] for p in pets)
+
+def test_read_pets_pagination(client: TestClient, test_pet_data_factory, created_test_owner):
+    for i in range(5):
+        pet_data = test_pet_data_factory(owner_id=created_test_owner["id"])
+        pet_data["name"] = f"Paginated Pet {i}"
+        client.post("/pets/", json=pet_data)
+
+    response_limit_2 = client.get("/pets/?skip=0&limit=2")
+    assert response_limit_2.status_code == 200
+    data_limit_2 = response_limit_2.json()
+    assert len(data_limit_2) == 2
+
+    response_skip_2_limit_2 = client.get("/pets/?skip=2&limit=2")
+    assert response_skip_2_limit_2.status_code == 200
+    data_skip_2_limit_2 = response_skip_2_limit_2.json()
+    assert len(data_skip_2_limit_2) == 2
+    assert data_limit_2[0]["id"] != data_skip_2_limit_2[0]["id"]


### PR DESCRIPTION
This pull request introduces several changes to improve the codebase for a veterinary application. The updates include schema adjustments to align with Pydantic v2, the addition of a robust testing framework with fixtures and test cases, and minor optimizations in imports. These changes enhance maintainability, testability, and compatibility with the latest tools.

### Schema Updates for Pydantic v2

* Replaced the `Config` class with `ConfigDict` to set `from_attributes=True`, removing the deprecated `orm_mode` in all schema files (`app/schemas/appointment.py`, `app/schemas/owner.py`, `app/schemas/pet.py`). [[1]](diffhunk://#diff-dd068e294df2e5563588d5ee992d8a8ae31dbdbad49b7590493f5e3d9af5a778R14-L17) [[2]](diffhunk://#diff-9abe8079883f34a1988aa78dc779626a465d13f8d4e542fbc3a322eaf68eb374R14-L18) [[3]](diffhunk://#diff-4c57c615d13b7e7b0292ae09142db65e179628b196f185bdf9a9325269c875deR15-L18)

### Testing Framework Enhancements

* Added `app/tests/conftest.py` with fixtures for a SQLite in-memory database, client setup, and test data factories for owners, pets, and appointments. This enables isolated and reusable test setups.
* Introduced test cases for CRUD operations and pagination for `owners`, `pets`, and `appointments` in `test_owners.py`, `test_pets.py`, and `test_appointments.py`. These ensure the correctness of API endpoints. [[1]](diffhunk://#diff-f77c9f910a46d390d9ee0b0b319f7e80f0ece0784203331e5059aee1e8ed8934R1-R56) [[2]](diffhunk://#diff-2700405e0b6f1c6ba8df87a7ada1e5ec807f140547380ff48c6edfe24c52123fR1-R64) [[3]](diffhunk://#diff-6071bd385c37b2f22fef4c19325ec3d3699d751f6dd369287d4f5c2aac411859R1-R81)
* Added a basic test for the root endpoint and a list-tables endpoint in `test_main.py`.

### Codebase Optimizations

* Consolidated imports in `app/db/database.py` and schema files to reduce redundancy and improve readability. [[1]](diffhunk://#diff-e4f878bfaca3eea7133a0689323ba4513537f8609db546d025fa55b83c4ab113L2-R2) [[2]](diffhunk://#diff-dd068e294df2e5563588d5ee992d8a8ae31dbdbad49b7590493f5e3d9af5a778L1-R1) [[3]](diffhunk://#diff-9abe8079883f34a1988aa78dc779626a465d13f8d4e542fbc3a322eaf68eb374L1-R1) [[4]](diffhunk://#diff-4c57c615d13b7e7b0292ae09142db65e179628b196f185bdf9a9325269c875deL1-R1)